### PR TITLE
Add support for looking up Profiles via merchantCustomerId

### DIFF
--- a/PaysafeSDK/src/main/java/com/paysafe/customervault/CustomerVaultService.java
+++ b/PaysafeSDK/src/main/java/com/paysafe/customervault/CustomerVaultService.java
@@ -740,7 +740,21 @@ public class CustomerVaultService {
    * @throws PaysafeException the paysafe exception
    */
   public final Profile lookup(final Profile profile) throws IOException, PaysafeException {
-    return lookup(profile, false, false);
+    if (profile.getMerchantCustomerId() != null && profile.getId() == null) {
+      HashMap<String, String> queryStr = new HashMap<>();
+      queryStr.put("merchantCustomerId", profile.getMerchantCustomerId());
+
+      final Request request = Request.builder()
+              .uri(prepareUri(PROFILE_PATH))
+              .method(Request.RequestType.GET)
+              .queryStr(queryStr)
+              .build();
+
+      Profile returnVal = client.processRequest(request, Profile.class);
+      return returnVal;
+    } else {
+      return lookup(profile, false, false);
+    }
   }
 
   /**


### PR DESCRIPTION
supported in the docs here: https://developer.paysafe.com/en/vault/api/#/reference/0/profiles/get-profile-using-merchant-customer-id

Normally I would've added a `lookupProfileViaMerchantCustomerId` but I saw `paysafeApiClient.cardPaymentService().getAuthWithMerchantRefNum` was removed in favour of `getAuths(Authorization)` with a `merchantRefNum` filled in on an `Authorization`, so I used that style